### PR TITLE
Make template compatible with Python 3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,4 +16,6 @@ fabio_pkg:     "fabio-{{ fabio_version }}-go{{ fabio_go_version }}-linux_amd64"
 fabio_pkg_url: "https://github.com/eBay/fabio/releases/download/v{{ fabio_version }}/fabio-{{ fabio_version }}-go{{ fabio_go_version }}-linux_amd64"
 fabio_properties_additional: {}
 fabio_properties_port: ":80"
+fabio_use_upstart: true
+fabio_use_systemd: false
 fabio_version: 1.3.4

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,12 +28,21 @@
 - include: install_binary.yml
   when: not fabio_install_from_source
 
-- name: Install Fabio service
+- name: Install Fabio Upstart service
   become: yes
   template:
     dest: /etc/init/fabio.conf
     mode: 0755
     src: "{{ fabio_service_template }}"
+  when: fabio_use_upstart
+
+- name: Install Fabio systemd service
+  become: yes
+  template:
+    dest: /etc/systemd/system/fabio.service
+    mode: 0755
+    src: fabio.systemd.j2
+  when: fabio_use_systemd
 
 - name: Enable Fabio service
   become: yes

--- a/templates/fabio.properties.j2
+++ b/templates/fabio.properties.j2
@@ -3,6 +3,6 @@
 
 proxy.addr = {{ fabio_properties_port }}
 
-{% for key, value in fabio_properties_additional.iteritems() %}
-{{ key }} = {{ value }}
+{% for key in fabio_properties_additional %}
+{{ key }} = {{ fabio_properties_additional[key] }}
 {% endfor %}

--- a/templates/fabio.systemd.j2
+++ b/templates/fabio.systemd.j2
@@ -1,0 +1,18 @@
+# fabio is a fast, modern, zero-conf load balancing HTTP(S) router for deploying applications managed by consul.
+# Home: https://github.com/eBay/fabio
+[Unit]
+Description=Fabio consul router
+Requires=consul.service
+After=consul.service
+
+[Service]
+Environment="GOMAXPROCS=`nproc`"
+Restart=on-failure
+User=fabio
+Group=fabio
+ExecStart={{ fabio_binary_path }}/fabio -cfg {{ fabio_directories_config }}/fabio.properties
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
If the local system's default Python version is 3, the fabio.properties template bombs out because it uses Python 2-style dict iteration. Change the template to use an iteration style that works in both Python 2 and 3.