### PR TITLE
Install Fabio binary in correct location

### DIFF
--- a/tasks/install_binary.yml
+++ b/tasks/install_binary.yml
@@ -14,6 +14,6 @@
 - name: Download fabio binary
   get_url:
     url: "{{ fabio_pkg_url }}"
-    dest: "/usr/local/bin/fabio"
+    dest: "{{ fabio_binary_path }}/fabio"
     mode: 0755
     checksum: "sha256:{{ chksum.stdout.split(' ')|first }}"


### PR DESCRIPTION
The binary install task assumed that the binary was going into `/usr/local/bin` even if `fabio_binary_path` was set to something else.