### PR TITLE
Use fact about full binary path

### DIFF
--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -18,7 +18,7 @@
 
 - name: Allow Fabio to bind to lower ports as non-privileged user
   capabilities:
-    path: "{{ fabio_binary_path }}/fabio"
+    path: "{{ fabio_binary_path_fact }}/fabio"
     capability: cap_net_bind_service=+ep
     state: present
 


### PR DESCRIPTION
As of now, if `fabio_symlink` ansible fails with error
```
fatal: [default]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to get capabilities of /usr/local/bin/fabio", "stderr": "", "stderr_lines": [], "stdout": "/usr/local/bin/fabio (Not a regular file)", "stdout_lines": ["/usr/local/bin/fabio (Not a regular file)"]}
```

