### PR TITLE
Vpiserchia patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ansible Fabio
 
-Master: [![Build Status](https://travis-ci.org/lobsterdore/ansible-fabio.svg?branch=master)](https://travis-ci.org/lobsterdore/ansible-fabio)
-Develop: [![Build Status](https://travis-ci.org/lobsterdore/ansible-fabio.svg?branch=develop)](https://travis-ci.org/lobsterdore/ansible-fabio)
+Master: [![Build Status](https://travis-ci.org/vpiserchia/ansible-fabio.svg?branch=master)](https://travis-ci.org/vpiserchia/ansible-fabio)
+Develop: [![Build Status](https://travis-ci.org/vpiserchia/ansible-fabio.svg?branch=develop)](https://travis-ci.org/vpiserchia/ansible-fabio)
 
 * [To install](#to-install)
 * [How to use](#how-to-use)
@@ -13,20 +13,18 @@ Installs and configures [Fabio](https://github.com/eBay/fabio).
 
 
 
-
 ## To install
 
 This role has been tested on the following operating systems:
-
-* Centos 6.8
-* Centos 7.3
-* Ubuntu 14.04
-* Ubuntu 16.04
+* --Centos 6.8--
+* --Centos 7.3--
+* --Ubuntu 14.04--
+* --Ubuntu 16.04--
 
 The easiest installation method is via Ansible Galaxy:
 
 ```BASH
-ansible-galaxy install lobsterdore.fabio
+ansible-galaxy install vpiserchia.fabio
 ```
 
 In requirements file:
@@ -35,12 +33,12 @@ In requirements file:
 ---
 # requirements.yml
 
-- src: lobsterdore.fabio
-  version: v1.2
+- src: vpiserchia.fabio
+  version: v1.3
 
 ```
 
-To see available versions please check this roles [Ansible Galaxy page](https://galaxy.ansible.com/lobsterdore/fabio/).
+To see available versions please check this roles [Ansible Galaxy page](https://galaxy.ansible.com/vpiserchia/fabio/).
 
 
 
@@ -125,7 +123,7 @@ make
 To run the tests you will the following prerequisites:
 
 * Docker
-* Python 2.7
+* Python 3.10
 * Python Virtualenv
 * Ruby 2.x
 * Ruby Bundler

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Installs and configures Fabio
   company: Lobsterdore
   license: MIT
-  min_ansible_version: 2.0
+  min_ansible_version: 2.16
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,14 +18,14 @@
     - "{{ fabio_directories_log }}"
   when: fabio_create_directories
 
-- include: install_src.yml
+- include_tasks: install_src.yml
   when: fabio_install_from_source
 
-- include: install_binary.yml
+- include_tasks: install_binary.yml
   when: not fabio_install_from_source
 
 - name: Create fabio user
-  include: user.yml
+  include_tasks: user.yml
   when: fabio_create_user
 
 - name: Install Fabio Upstart service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Install
-  include: install.yml
+  include_tasks: install.yml
   tags:
     - build
 
 - name: Configure
-  include: configure.yml
+  include_tasks: configure.yml
   tags:
     - configure


### PR DESCRIPTION
Use ```include_tasks``` instead of ```include``` module since the former has been removed in major release after 2023-05-16

```
    https://github.com/ansible/ansible/blob/v2.16.0/changelogs/CHANGELOG-v2.16.rst
        Removed include which has been deprecated in Ansible 2.12. Use include_tasks or import_tasks instead.
```

